### PR TITLE
Addition of LICENSE information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Paul Colomiets
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,20 @@ Cantal consists of:
 * Local agent to collect/aggregate/forward data
 * A protocol for forwarding data to aggregator (carbon/graphite)
 
+License
+=======
 
+Licensed under
+
+* MIT license (LICENSE_ or http://opensource.org/licenses/MIT)
+
+Contribution
+------------
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, shall be licensed under
+the MIT license, without any additional terms or conditions.
+
+.. _LICENSE: https://github.com/tailhook/cantal-py
 .. _cantal-py: https://github.com/tailhook/cantal-py
 

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,6 @@ Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, shall be licensed under
 the MIT license, without any additional terms or conditions.
 
-.. _LICENSE: https://github.com/tailhook/cantal-py
+.. _LICENSE: https://github.com/tailhook/cantal/blob/master/LICENSE
 .. _cantal-py: https://github.com/tailhook/cantal-py
 


### PR DESCRIPTION
As communicated over email. This pull request is for the addition of a LICENSE file with the MIT license information to prevent misunderstanding in terms of the licensing.

I also added a short note in the README.rst with a similar Contribution section as is currently in cantal-py

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.